### PR TITLE
Add equals and hashCode into SimilarityProvider

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -47,5 +47,39 @@ public final class SimilarityProvider {
     public Similarity get() {
         return similarity;
     }
+    
+     /*
+   * Compute the hashcode on name {@link Similarity}.
+   */
+   @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((name == null) ? 0 : name.hashCode());
+      return result;
+   }
+
+   /*
+   * Check if SimilarityProvider reference or name are equals {@link Similarity}.
+   */
+   @Override
+   public boolean equals(final Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+         return false;
+      }
+
+      SimilarityProvider other = (SimilarityProvider) obj;
+      if (name == null) {
+         if (other.name != null) {
+            return false;
+         }
+      } else if (!name.equals(other.name)) {
+         return false;
+      }
+      return true;
+   }
 
 }


### PR DESCRIPTION
When elastissearch updates the mapping containing multiple fields related to the same custom similarity, it generates a wrong conflict:

Iniside org.elasticsearch.index.mapper.MappedFieldType.checkCompatibility() operation the code checks the equality between similarityprovider and the reference can be different 
>>
        if (Objects.equals(similarity(), other.similarity()) == false) {
            conflicts.add("mapper [" + name() + "] has different [similarity]");
        }
>>

org.elasticsearch.index.similarity.SimilarityService create a new SimilarityProvider when getSimilarity is called

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
